### PR TITLE
천둥 박수 -> 뇌명

### DIFF
--- a/Mods/MystraSpellKorean_22d05cf9-61db-83e5-4362-a5c7d6893866/Localization/Korean/korean.xml
+++ b/Mods/MystraSpellKorean_22d05cf9-61db-83e5-4362-a5c7d6893866/Localization/Korean/korean.xml
@@ -71,7 +71,7 @@
  <content contentuid="h89c631fag496fga73dg73a2g15b0d865642b" version="1">이 주문은 침묵 상태일 때도 시전할 수 있습니다.</content>
  <content contentuid="h25851994gbb93gd31dg7067g4a23fb65dbae" version="1">이 주문은 침묵 상태일 때도 시전할 수 있습니다.</content>
  <content contentuid="h75e87092gcde9gf5a5g1e5fgac3a3f40b12b" version="1">이 주문은 침묵 상태일 때도 시전할 수 있습니다.</content>
- <content contentuid="h58a91b66gbb02g4a2dg2c3cg9efa6fe61444" version="1">천둥 박수</content>
+ <content contentuid="h58a91b66gbb02g4a2dg2c3cg9efa6fe61444" version="1">뇌명</content>
  <content contentuid="h000b1c39g064fg0620g23a8gefc361fc5505" version="1">천둥치는 듯한 소리를 만들어냅니다.</content>
  <content contentuid="h481e6f2dg7e6eg6576g2e3fgb9fd69646bec" version="1">이 주문은 침묵 상태일 때도 시전할 수 있습니다.</content>
  <content contentuid="hb46ce668g566fg9e96g44a5gb384c2f59866" version="1">원소 흡수</content>


### PR DESCRIPTION
ThunderClap은 Thunder + Clap 보단 천둥소리 내지는 천둥같이 폭발적인 소리를 묘사하는 단어이므로 동의한 의미를 가지는 '뇌명' 또는 '우레' 같은 번역을 추천함